### PR TITLE
fix: switch image gen to OpenAI direct (DEV-2180)

### DIFF
--- a/src/lib/image-gen.ts
+++ b/src/lib/image-gen.ts
@@ -154,7 +154,7 @@ export async function generateImage(sourceText: string, promptTemplate: string):
 
 export async function refineImage(imageBuffer: Buffer, refinementPrompt: string): Promise<Buffer> {
   const formData = new FormData()
-  formData.append('image', new Blob([imageBuffer], { type: 'image/png' }), 'source.png')
+  formData.append('image', new Blob([new Uint8Array(imageBuffer)], { type: 'image/png' }), 'source.png')
   formData.append('prompt', refinementPrompt)
   formData.append('model', 'gpt-image-1')
   formData.append('size', '1024x1024')


### PR DESCRIPTION
## Summary
- `openai/gpt-image-1` was removed from OpenRouter, causing 500 on all image generation
- Switched `generateImage` to OpenAI direct API (`/v1/images/generations`)
- Switched `refineImage` to OpenAI edit API (`/v1/images/edits`) with FormData
- Added `OPENAI_API_KEY` to Vercel production env
- Tested generation locally — confirmed working

## Test plan
- [x] Local test script confirmed 200 + valid PNG from OpenAI images API
- [x] Codex code review passed (no blocking issues)
- [ ] Verify image generation works on prod after deploy
- [ ] Verify image refinement works on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)